### PR TITLE
Remove hard coded region

### DIFF
--- a/samconfig.toml
+++ b/samconfig.toml
@@ -2,6 +2,5 @@ version = 0.1
 [default]
 [default.deploy]
 [default.deploy.parameters]
-region = "us-east-1"
 confirm_changeset = true
 capabilities = "CAPABILITY_NAMED_IAM"


### PR DESCRIPTION
Region 'us-east-1' was hard coded in the SAM
config.This would not allow the customer to
deploy stack in some other region unless it
is changed in the config. Removing it will
ensure that the region is picked up from
developers aws config.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
