### PR TITLE
Add encryption for SQS and Kinesis

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -250,9 +250,14 @@ Resources:
       Name: RegistrationStreamKinesis
       RetentionPeriodHours: 168
       ShardCount: 1
+      StreamEncryption:
+        EncryptionType: KMS
+        KeyId: alias/aws/kinesis
 
   RegistrationIndexerFailureQueue:
     Type: AWS::SQS::Queue
+    Properties:
+      KmsMasterKeyId: alias/aws/sqs
 
   ElasticsearchDomain:
     Type: AWS::Elasticsearch::Domain


### PR DESCRIPTION
*Issue #, if available:*

Data passing through SQS may remain on SQS service hosts for some time. During that time, a breach of SQS could potentially expose that data. Data should be encrypted as it passes through SQS.

We need to encrypt all data that passes through SQS via SQS Server Side Encryption (SSE) with KMS managed encryption keys.

Kinesis will store the data that passes through it on disk for a period of 7 days before it starts to expire. It does not encrypt the data at rest by default so it is important to encrypt your data before you pass it through the Kinesis stream or enable server side encryption for streams or Firehose.

* SIM for tracking: https://issues.amazon.com/issues/DE-13526

* Original TTs:
     * https://t.corp.amazon.com/V370822815
     * https://t.corp.amazon.com/V370822850

*Description of changes:*

Enable encryption on Kinesis stream and SQS queue.

Following the guidelines: 
* https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-sqs-queues.html
* https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-kinesis-stream-streamencryption.html#cfn-kinesis-stream-streamencryption-encryptiontype


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
